### PR TITLE
if we can add loaderContext param `ctx` in injector function ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ module.exports = {
                         path.resolve(__dirname, 'path/to/stylus/variables/*.styl'),
                         path.resolve(__dirname, 'path/to/stylus/mixins/*.styl')
                     ],
-                    injector: (source, resources) => {
+                    injector: (source, resources, ctx) => {
                         const combineAll = type => resources
                             .filter(({ file }) => file.includes(type))
                             .map(({ content }) => content)
@@ -157,15 +157,16 @@ It defaults to `'prepend'`, which implements as an injector function internally.
 Furthermore, an injector function should match the following type signature:
 
 ```ts
-(source: string, resources: StyleResource[]) => string | Promise<string>
+(source: string, resources: StyleResource[], ctx: LoaderContext) => string | Promise<string>
 ```
 
-It receives two parameters:
+It receives three parameters:
 
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
 |**`source`**|`{string}`|`/`|Content of the source file|
 |**[`resources`](#resources)**|`{StyleResource[]}`|`/`|Resource descriptors|
+|**`ctx`**|`{LoaderContext}`|`/`|loader context|
 
 #### `resources`
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -26,9 +26,6 @@ export const schema: Schema = {
                 {
                     instanceof: 'Function',
                 },
-                {
-                    type: 'object',
-                },
             ],
         },
         globOptions: {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -26,6 +26,9 @@ export const schema: Schema = {
                 {
                     instanceof: 'Function',
                 },
+                {
+                    type: 'object',
+                },
             ],
         },
         globOptions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface StyleResource {
 
 export type StyleResources = StyleResource[];
 
-export type StyleResourcesFunctionalInjector = (source: string, resources: StyleResources) => string | Promise<string>;
+export type StyleResourcesFunctionalInjector = (source: string, resources: StyleResources, ctx: LoaderContext) => string | Promise<string>;
 
 export type StyleResourcesInjector = 'prepend' | 'append' | StyleResourcesFunctionalInjector;
 

--- a/src/utils/inject-resources.ts
+++ b/src/utils/inject-resources.ts
@@ -1,3 +1,4 @@
+import { LoaderContext } from '../types';
 import type {StyleResources, StyleResourcesLoaderNormalizedOptions} from '..';
 
 import {errorMessage} from './error-message';
@@ -6,10 +7,11 @@ export const injectResources = async (
     options: StyleResourcesLoaderNormalizedOptions,
     source: string,
     resources: StyleResources,
+    ctx: LoaderContext
 ) => {
     const {injector} = options;
 
-    const dist: unknown = injector(source, resources);
+    const dist: unknown = injector(source, resources, ctx);
 
     const content = await dist;
 

--- a/src/utils/load-resources.ts
+++ b/src/utils/load-resources.ts
@@ -10,7 +10,7 @@ export const loadResources = async (ctx: LoaderContext, source: string, callback
 
         const resources = await getResources(ctx, options);
 
-        const content = await injectResources(options, source, resources);
+        const content = await injectResources(options, source, resources, ctx);
 
         callback(null, content);
     } catch (err) {


### PR DESCRIPTION
when we need to decide what to inject based on the loader context, it will be very helpful.

for example:
```
injector(source, resources, ctx) {
  function findEntry(mod) {
    if (
      mod.reasons.length > 0 &&
      mod.reasons[0].module.resource
    ) {
      return findEntry(mod.reasons[0].module);
    }
    return mod.resource;
  }
  const entryName = findEntry(ctx._module);
  // more code
},
```

